### PR TITLE
feat: 掲示グループの選択・変更機能を追加 (#1)

### DIFF
--- a/src/lib/vrcApi.ts
+++ b/src/lib/vrcApi.ts
@@ -57,4 +57,22 @@ export const vrcApi = {
       visibility,
     });
   },
+
+  /**
+   * 掲示中のグループを取得する
+   */
+  async getRepresentedGroup(): Promise<VRChatGroup[]> {
+    const response = await invoke<VRChatGroup[]>("get_represented_group", {});
+    return response;
+  },
+
+  /**
+   * 指定したグループを掲示する(掲示中の場合を掲示停止する)
+   */
+  async updateGroupRepresentation(groupId: string, isRepresenting: boolean): Promise<void> {
+    await invoke("update_group_representation", {
+      groupId,
+      isRepresenting,
+    });
+  },
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,7 @@ export interface VRChatGroup {
   memberVisibility: GroupVisibility;
   memberCount?: number;
   createdAt?: string;
+  isRepresenting: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- グループの掲示（Represent）設定を切り替える機能を追加
- 楽観的更新（Optimistic Update）とロールバックによるスムーズなUX
- 掲示モードの切り替えUIを実装

## 変更内容
- **Rust バックエンド**: `get_represented_group` / `update_group_representation` APIコマンド追加
- **TypeScript 型定義**: `VRChatGroup` に `isRepresenting` フィールド追加
- **フロントエンド API**: `vrcApi` に掲示関連メソッド追加
- **UI**: 掲示モード切替ボタン、行クリックで掲示切替、「掲示中」バッジ表示

## Test plan
- [ ] 掲示モードの切り替えが正常に動作すること
- [ ] グループ行クリックで掲示状態が切り替わること
- [ ] API失敗時にロールバックされること
- [ ] 掲示中バッジが正しく表示されること

Closes #1