### PR TITLE
feat: テーマ切り替え機能を追加 (#3)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ use tauri::AppHandle;
 use tauri_plugin_updater::UpdaterExt;
 
 mod error;
+mod settings_store;
 mod token_store;
 mod vrc_api;
 
@@ -66,6 +67,8 @@ pub fn run() {
             check_for_updates,
             get_represented_group,
             update_group_representation,
+            get_settings,
+            save_settings_cmd,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
@@ -183,5 +186,20 @@ async fn update_group_representation(
 
     vrc_api::update_group_representation(&token, &group_id, &is_representing).await?;
 
+    Ok(())
+}
+
+#[tauri::command]
+fn get_settings(app: AppHandle) -> std::result::Result<settings_store::AppSettings, String> {
+    let settings = settings_store::load_settings(&app)?;
+    Ok(settings)
+}
+
+#[tauri::command]
+fn save_settings_cmd(
+    app: AppHandle,
+    settings: settings_store::AppSettings,
+) -> std::result::Result<(), String> {
+    settings_store::save_settings(&app, &settings)?;
     Ok(())
 }

--- a/src-tauri/src/settings_store.rs
+++ b/src-tauri/src/settings_store.rs
@@ -1,0 +1,86 @@
+use crate::error::{AppError, Result};
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use tauri::Manager;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AppSettings {
+    #[serde(default)]
+    pub ui: UiSettings,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UiSettings {
+    #[serde(default)]
+    pub theme: String, // "light" | "dark" | "system"
+    pub language: String, // "ja" | "en"
+}
+
+impl Default for UiSettings {
+    fn default() -> Self {
+        Self {
+            theme: "system".to_string(),
+            language: "ja".to_string(),
+        }
+    }
+}
+
+fn settings_path(app: &tauri::AppHandle) -> Result<PathBuf> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| AppError::Storage(format!("Failed to get app data dir: {}", e)))?;
+
+    Ok(dir.join("settings.json"))
+}
+
+pub fn load_settings(app: &tauri::AppHandle) -> Result<AppSettings> {
+    let path = settings_path(app)?;
+
+    // ファイルが存在しない場合はデフォルト値を返す
+    if !path.exists() {
+        info!("Settings file not found, using defaults");
+        return Ok(AppSettings::default());
+    }
+    // ファイルを読み込み
+    let content = fs::read_to_string(&path)
+        .map_err(|e| AppError::Storage(format!("Failed to read settings: {}", e)))?;
+
+    // JSONをパース（失敗したらデフォルト値を返す）
+    match serde_json::from_str::<AppSettings>(&content) {
+        Ok(settings) => Ok(settings),
+        Err(e) => {
+            warn!("Failed to parse settings ({}), using defaults", e);
+            Ok(AppSettings::default())
+        }
+    }
+}
+
+pub fn save_settings(app: &tauri::AppHandle, settings: &AppSettings) -> Result<()> {
+    let path = settings_path(app)?;
+
+    // 親ディレクトリが存在しなければ作成
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent)
+                .map_err(|e| AppError::Storage(format!("Failed to create dir: {}", e)))?;
+        }
+    }
+
+    // JSONに変換して書き込み
+    let content = serde_json::to_string_pretty(settings)
+        .map_err(|e| AppError::Storage(format!("Failed to serialize settings: {}", e)))?;
+
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, content)
+        .map_err(|e| AppError::Storage(format!("Failed to write tmp: {}", e)))?;
+
+    fs::rename(&tmp_path, &path)
+        .map_err(|e| AppError::Storage(format!("Failed to rename settings: {}", e)))?;
+    info!("Settings saved to {:?}", path);
+    Ok(())
+}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,14 +3,16 @@ import { Toaster } from "@/app/components/ui/sonner";
 import { GroupsPage } from "@/app/pages/GroupsPage";
 import { LoginPage } from "@/app/pages/LoginPage";
 import { SettingsPage } from "@/app/pages/SettingsPage";
-import type { UserInfo } from "@/types";
+import { useTheme } from "@/hooks/useTheme";
 import { vrcApi } from "@/lib/vrcApi";
+import type { UserInfo } from "@/types";
 import { useEffect, useState } from "react";
 
 const App = () => {
   const [currentUser, setCurrentUser] = useState<UserInfo | null>(null);
   const [currentView, setCurrentView] = useState<SidebarView>("groups");
   const [isLoading, setIsLoading] = useState(true);
+  const { theme, setTheme } = useTheme();
 
   // 起動時に保存されたトークンを確認
   useEffect(() => {
@@ -54,7 +56,7 @@ const App = () => {
   // ローディング中
   if (isLoading) {
     return (
-      <div className="size-full flex items-center justify-center bg-gray-100">
+      <div className="size-full flex items-center justify-center bg-muted">
         <div className="text-center">
           <div className="size-12 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
           <p className="text-muted-foreground">読み込み中...</p>
@@ -81,7 +83,12 @@ const App = () => {
       <main className="flex-1 overflow-auto">
         {currentView === "groups" && <GroupsPage currentUser={currentUser} />}
         {currentView === "settings" && (
-          <SettingsPage currentUser={currentUser} onLogout={handleLogout} />
+          <SettingsPage
+            currentUser={currentUser}
+            onLogout={handleLogout}
+            theme={theme}
+            onThemeChange={setTheme}
+          />
         )}
       </main>
 

--- a/src/app/components/AppSidebar.tsx
+++ b/src/app/components/AppSidebar.tsx
@@ -15,8 +15,8 @@ export const AppSidebar = ({ currentView, onViewChange }: AppSidebarProps) => {
   ];
 
   return (
-    <aside className="w-64 bg-white border-r border-gray-200 flex flex-col">
-      <div className="p-4 border-b border-gray-200">
+    <aside className="w-64 bg-card border-r border-border flex flex-col">
+      <div className="p-4 border-b border-border">
         <h1 className="font-semibold text-lg">VRChat グループ</h1>
       </div>
 
@@ -31,7 +31,7 @@ export const AppSidebar = ({ currentView, onViewChange }: AppSidebarProps) => {
               onClick={() => onViewChange(item.id)}
               className={cn(
                 "w-full flex items-center gap-3 px-3 py-2 rounded-lg transition-colors",
-                isActive ? "bg-blue-50 text-blue-700" : "text-gray-700 hover:bg-gray-100",
+                isActive ? "bg-primary/10 text-primary" : "text-foreground hover:bg-accent",
               )}
             >
               <Icon className="size-5" />

--- a/src/app/components/figma/ImageWithFallback.tsx
+++ b/src/app/components/figma/ImageWithFallback.tsx
@@ -14,7 +14,7 @@ export const ImageWithFallback = (props: ImgHTMLAttributes<HTMLImageElement>) =>
 
   return didError ? (
     <div
-      className={`inline-block bg-gray-100 text-center align-middle ${className ?? ""}`}
+      className={`inline-block bg-muted text-center align-middle ${className ?? ""}`}
       style={style}
     >
       <div className="flex items-center justify-center w-full h-full">

--- a/src/app/pages/GroupsPage.tsx
+++ b/src/app/pages/GroupsPage.tsx
@@ -185,7 +185,7 @@ export const GroupsPage = ({ currentUser }: GroupsPageProps) => {
     const colors: Record<GroupVisibility, string> = {
       visible: "bg-green-100 text-green-800",
       friends: "bg-blue-100 text-blue-800",
-      hidden: "bg-gray-100 text-gray-800",
+      hidden: "bg-muted text-foreground",
     };
     return colors[visibility];
   };
@@ -232,9 +232,9 @@ export const GroupsPage = ({ currentUser }: GroupsPageProps) => {
   };
 
   return (
-    <div className="flex-1 flex flex-col h-full bg-gray-50">
+    <div className="flex-1 flex flex-col h-full bg-muted">
       {/* ヘッダー */}
-      <div className="bg-white border-b border-gray-200 p-4 flex-shrink-0">
+      <div className="bg-card border-b border-border p-4 flex-shrink-0">
         <div className="flex items-center justify-between mb-4">
           <div>
             <h2 className="text-xl font-semibold">グループ管理</h2>
@@ -332,12 +332,12 @@ export const GroupsPage = ({ currentUser }: GroupsPageProps) => {
       {/* グループリスト */}
       <div className="flex-1 overflow-auto">
         <div className="p-4">
-          <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+          <div className="bg-card rounded-lg border border-border overflow-hidden">
             {/* ヘッダー */}
             <div
               className={`grid ${
                 isRepresentMode ? "grid-cols-[1fr_150px_80px]" : "grid-cols-[50px_1fr_150px_80px]"
-              } gap-4 p-4 bg-gray-50 border-b border-gray-200 font-medium text-sm`}
+              } gap-4 p-4 bg-background border-b border-border font-medium text-sm`}
             >
               {!isRepresentMode && (
                 <div className="flex items-center">
@@ -354,7 +354,7 @@ export const GroupsPage = ({ currentUser }: GroupsPageProps) => {
             </div>
 
             {/* グループリスト */}
-            <div className="divide-y divide-gray-200">
+            <div className="divide-y divide-border">
               {filteredGroups.map((group) => (
                 <div
                   key={group.groupId}
@@ -365,7 +365,7 @@ export const GroupsPage = ({ currentUser }: GroupsPageProps) => {
                   } gap-4 p-4 transition-colors ${
                     isRepresenting
                       ? "opacity-50 pointer-events-none"
-                      : "hover:bg-gray-50 cursor-pointer"
+                      : "hover:bg-muted/70 cursor-pointer"
                   }`}
                   onClick={
                     isRepresenting
@@ -392,7 +392,7 @@ export const GroupsPage = ({ currentUser }: GroupsPageProps) => {
                       <img
                         src={group.iconUrl}
                         alt=""
-                        className="size-10 rounded-full bg-gray-100 flex-shrink-0"
+                        className="size-10 rounded-full bg-muted flex-shrink-0"
                       />
                     )}
                     <div className="min-w-0">

--- a/src/app/pages/SettingsPage.tsx
+++ b/src/app/pages/SettingsPage.tsx
@@ -16,70 +16,37 @@ import {
 } from "@/app/components/ui/select";
 import { Separator } from "@/app/components/ui/separator";
 import { Switch } from "@/app/components/ui/switch";
-import type { AppSettings, UserInfo } from "@/types";
+import type { UserInfo } from "@/types";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check } from "@tauri-apps/plugin-updater";
 import { Activity, Bell, Code, FileText, Info, LogOut, Palette, RefreshCw } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { Badge } from "../components/ui/badge";
 
 interface SettingsPageProps {
   currentUser: UserInfo;
   onLogout: () => void;
+  theme: string;
+  onThemeChange: (theme: "light" | "dark" | "system") => void;
 }
 
 const APP_VERSION = "0.2.3";
 const DEVELOPER_NAME = "takadayoo_1203";
 
-export const SettingsPage = ({ currentUser, onLogout }: SettingsPageProps) => {
-  const [settings, setSettings] = useState<AppSettings>({
-    notifications: {
-      enabled: true,
-      groupUpdates: true,
-    },
-    ui: {
-      theme: "system",
-      language: "ja",
-    },
-    logs: {
-      enabled: true,
-      level: "info",
-    },
-  });
+export const SettingsPage = ({
+  currentUser,
+  onLogout,
+  theme,
+  onThemeChange,
+}: SettingsPageProps) => {
+  // stateではなく定数で十分
+  const dummySettings = {
+    notifications: { enabled: true, groupUpdates: true },
+    ui: { language: "ja" },
+    logs: { enabled: true, level: "info" },
+  };
   const [isCheckingUpdate, setIsCheckingUpdate] = useState(false);
-
-  useEffect(() => {
-    loadSettings();
-  }, []);
-
-  const loadSettings = async () => {
-    try {
-      // TODO: Tauriのinvokeコマンドで設定を取得
-      // const response = await invoke<TauriResponse<AppSettings>>('get_settings');
-      // if (response.success && response.data) {
-      //   setSettings(response.data);
-      // }
-    } catch (error) {
-      console.error("Failed to load settings:", error);
-    }
-  };
-
-  const saveSettings = async (newSettings: AppSettings) => {
-    try {
-      // TODO: Tauriのinvokeコマンドで設定を保存
-      // const response = await invoke<TauriResponse<void>>('update_settings', { settings: newSettings });
-      // if (response.success) {
-      setSettings(newSettings);
-      toast.success("設定を保存しました");
-      // } else {
-      //   toast.error('設定の保存に失敗しました');
-      // }
-    } catch (error) {
-      console.error("Failed to save settings:", error);
-      toast.error("設定の保存中にエラーが発生しました");
-    }
-  };
 
   const handleCheckUpdate = async () => {
     setIsCheckingUpdate(true);
@@ -138,7 +105,7 @@ export const SettingsPage = ({ currentUser, onLogout }: SettingsPageProps) => {
   };
 
   return (
-    <div className="flex-1 h-full overflow-auto bg-gray-50">
+    <div className="flex-1 h-full overflow-auto bg-muted">
       <div className="max-w-4xl mx-auto p-6 space-y-6">
         <div>
           <h2 className="text-2xl font-semibold mb-1">設定</h2>
@@ -166,12 +133,7 @@ export const SettingsPage = ({ currentUser, onLogout }: SettingsPageProps) => {
         </Card>
 
         {/* UI表示設定 */}
-        <Card className="relative opacity-60 pointer-events-none">
-          <div className="absolute top-4 right-4 z-10">
-            <Badge variant="secondary" className="bg-yellow-100 text-yellow-800">
-              近日実装予定
-            </Badge>
-          </div>
+        <Card className="relative">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Palette className="size-5" />
@@ -188,17 +150,8 @@ export const SettingsPage = ({ currentUser, onLogout }: SettingsPageProps) => {
                 </p>
               </div>
               <Select
-                value={settings.ui.theme}
-                onValueChange={(value) => {
-                  const newSettings = {
-                    ...settings,
-                    ui: {
-                      ...settings.ui,
-                      theme: value as "light" | "dark" | "system",
-                    },
-                  };
-                  saveSettings(newSettings);
-                }}
+                value={theme}
+                onValueChange={(value) => onThemeChange(value as "light" | "dark" | "system")}
               >
                 <SelectTrigger className="w-40">
                   <SelectValue />
@@ -219,14 +172,9 @@ export const SettingsPage = ({ currentUser, onLogout }: SettingsPageProps) => {
                 <p className="text-sm text-muted-foreground">表示言語を選択</p>
               </div>
               <Select
-                value={settings.ui.language}
-                onValueChange={(value) => {
-                  const newSettings = {
-                    ...settings,
-                    ui: { ...settings.ui, language: value as "ja" | "en" },
-                  };
-                  saveSettings(newSettings);
-                }}
+                value={dummySettings.ui.language}
+                disabled
+                // onValueChange={}
               >
                 <SelectTrigger className="w-40">
                   <SelectValue />
@@ -261,17 +209,8 @@ export const SettingsPage = ({ currentUser, onLogout }: SettingsPageProps) => {
                 <p className="text-sm text-muted-foreground">デスクトップ通知を表示</p>
               </div>
               <Switch
-                checked={settings.notifications.enabled}
-                onCheckedChange={(checked) => {
-                  const newSettings = {
-                    ...settings,
-                    notifications: {
-                      ...settings.notifications,
-                      enabled: checked,
-                    },
-                  };
-                  saveSettings(newSettings);
-                }}
+                checked={dummySettings.notifications.enabled}
+                // onCheckedChange={}
               />
             </div>
 
@@ -283,18 +222,9 @@ export const SettingsPage = ({ currentUser, onLogout }: SettingsPageProps) => {
                 <p className="text-sm text-muted-foreground">グループの変更時に通知</p>
               </div>
               <Switch
-                checked={settings.notifications.groupUpdates}
-                onCheckedChange={(checked) => {
-                  const newSettings = {
-                    ...settings,
-                    notifications: {
-                      ...settings.notifications,
-                      groupUpdates: checked,
-                    },
-                  };
-                  saveSettings(newSettings);
-                }}
-                disabled={!settings.notifications.enabled}
+                checked={dummySettings.notifications.groupUpdates}
+                // onCheckedChange={}
+                disabled={!dummySettings.notifications.enabled}
               />
             </div>
           </CardContent>
@@ -321,14 +251,8 @@ export const SettingsPage = ({ currentUser, onLogout }: SettingsPageProps) => {
                 <p className="text-sm text-muted-foreground">アプリケーションログを記録</p>
               </div>
               <Switch
-                checked={settings.logs.enabled}
-                onCheckedChange={(checked) => {
-                  const newSettings = {
-                    ...settings,
-                    logs: { ...settings.logs, enabled: checked },
-                  };
-                  saveSettings(newSettings);
-                }}
+                checked={dummySettings.logs.enabled}
+                // onCheckedChange={}
               />
             </div>
 
@@ -340,18 +264,9 @@ export const SettingsPage = ({ currentUser, onLogout }: SettingsPageProps) => {
                 <p className="text-sm text-muted-foreground">記録する詳細レベル</p>
               </div>
               <Select
-                value={settings.logs.level}
-                onValueChange={(value) => {
-                  const newSettings = {
-                    ...settings,
-                    logs: {
-                      ...settings.logs,
-                      level: value as "info" | "debug" | "error",
-                    },
-                  };
-                  saveSettings(newSettings);
-                }}
-                disabled={!settings.logs.enabled}
+                value={dummySettings.logs.level}
+                // onValueChange={}
+                disabled={!dummySettings.logs.enabled}
               >
                 <SelectTrigger className="w-40">
                   <SelectValue />

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,63 @@
+import { vrcApi } from "@/lib/vrcApi";
+import { useEffect, useState } from "react";
+
+type Theme = "light" | "dark" | "system";
+
+function applyTheme(theme: Theme) {
+  const isDark =
+    theme === "dark" ||
+    (theme === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+  document.documentElement.classList.toggle("dark", isDark);
+}
+
+export const useTheme = () => {
+  const [theme, setThemeState] = useState<Theme>("system");
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // 初期化: Rust側から設定を読み込んで適用
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const settings = await vrcApi.getSettings();
+        setThemeState(settings.ui.theme);
+      } catch {
+        applyTheme("system");
+      } finally {
+        setIsLoaded(true);
+      }
+    };
+    init();
+  }, []);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  // systemモード時のみOS設定変更を監視
+  useEffect(() => {
+    if (theme !== "system") return;
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = () => applyTheme("system");
+
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [theme]);
+
+  // テーマ変更 → DOM反映 → Rust側に保存
+  const handleSetTheme = async (newTheme: Theme) => {
+    setThemeState(newTheme);
+    try {
+      const current = await vrcApi.getSettings();
+      await vrcApi.saveSettings({
+        ...current,
+        ui: { ...current.ui, theme: newTheme },
+      });
+    } catch (e) {
+      console.error("Failed to save theme:", e);
+    }
+  };
+
+  return { theme, setTheme: handleSetTheme, isLoaded } as const;
+};

--- a/src/lib/vrcApi.ts
+++ b/src/lib/vrcApi.ts
@@ -1,4 +1,4 @@
-import type { GroupVisibility, UserInfo, VRChatGroup } from "@/types";
+import type { AppSettings, GroupVisibility, UserInfo, VRChatGroup } from "@/types";
 import { invoke } from "@tauri-apps/api/core";
 
 /**
@@ -74,5 +74,19 @@ export const vrcApi = {
       groupId,
       isRepresenting,
     });
+  },
+
+  /**
+   * アプリ設定を取得
+   */
+  async getSettings(): Promise<AppSettings> {
+    return await invoke<AppSettings>("get_settings");
+  },
+
+  /**
+   * アプリ設定を保存
+   */
+  async saveSettings(settings: AppSettings): Promise<void> {
+    await invoke("save_settings_cmd", { settings });
   },
 };


### PR DESCRIPTION
## 概要
- ライト/ダーク/システム追従の3モードでテーマを切り替える機能を追加
- Rust側に設定永続化基盤（settings_store）を新規実装
- ハードコードされた色をセマンティックカラーに置換し、ダークモード対応

## 変更内容
- `settings_store.rs`: アプリ設定のJSON読み書き（app_data_dir に保存）
- `useTheme` フック: テーマ切り替えロジック、OS設定追従、設定の自動保存
- `SettingsPage`: テーマ選択UIを有効化、不要なTODOコードを削除
- 各コンポーネント: `bg-gray-*` 等をテーマ対応色（`bg-muted`, `bg-card` 等）に置換

Closes #3