### PR TITLE
CI/CDパイプラインの構築とプレリリース対応 #7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Node.jsのセットアップ
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Rust stableのインストール
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rustキャッシュ
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - name: フロントエンド依存関係のインストール
+        run: npm install
+
+      - name: プレリリース判定
+        id: check_prerelease
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_name }}" == *"-"* ]]; then
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: ビルドとリリース
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: "VRChat Group Manager ${{ github.ref_name }}"
+          releaseDraft: false
+          prerelease: ${{ steps.check_prerelease.outputs.is_prerelease }}
+
+      - name: プレリリース固定タグの更新
+        if: steps.check_prerelease.outputs.is_prerelease == 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete pre-release --yes --cleanup-tag || true
+          gh release download "${{ github.ref_name }}" \
+            --pattern "latest.json" \
+            --dir "${{ runner.temp }}/release-assets"
+          gh release create pre-release \
+            --prerelease \
+            --title "Pre-release（最新）" \
+            --notes "このリリースは常に最新のプレリリース版を指します" \
+            "${{ runner.temp }}/release-assets/latest.json"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,37 @@
+name: Version Check
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  version-check:
+    name: Version Consistency Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: バージョン一致チェック
+        shell: bash
+        run: |
+          PKG=$(jq -r '.version' package.json)
+          CARGO=$(grep '^version' src-tauri/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          TAURI=$(jq -r '.version' src-tauri/tauri.conf.json)
+
+          echo "package.json    : $PKG"
+          echo "Cargo.toml      : $CARGO"
+          echo "tauri.conf.json : $TAURI"
+
+          if [ "$PKG" != "$CARGO" ] || [ "$PKG" != "$TAURI" ]; then
+            echo ""
+            echo "❌ バージョンが一致していません"
+            echo "リリース前に3ファイルのバージョンを揃えてください"
+            exit 1
+          fi
+
+          echo ""
+          echo "✅ バージョンが一致しています: $PKG"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4769,6 +4769,7 @@ dependencies = [
  "tauri-plugin-updater",
  "thiserror 2.0.17",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1", features = ["sync"] }
 thiserror = "2.0"
 keyring = { version = "3", features = ["apple-native", "windows-native"] }
 tauri-plugin-updater = "2.9.0"
+url = "2"
 
 [profile.release]
 panic = "abort"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,10 +1,10 @@
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
-use tauri_plugin_updater::UpdaterExt;
 
 mod error;
 mod settings_store;
 mod token_store;
+mod update_handler;
 mod vrc_api;
 
 /// ユーザー情報レスポンス
@@ -64,6 +64,7 @@ pub fn run() {
             load_token,
             delete_token,
             check_for_updates,
+            install_update,
             get_represented_group,
             update_group_representation,
             get_settings,
@@ -118,13 +119,16 @@ async fn update_group_status(
     Ok(())
 }
 
+/// アップデートを確認する
 #[tauri::command]
-async fn check_for_updates(app: AppHandle) -> Result<bool, String> {
-    let updater = app.updater().map_err(|e| e.to_string())?;
+async fn check_for_updates(app: AppHandle) -> Result<Option<update_handler::UpdateInfo>, String> {
+    update_handler::check(&app).await
+}
 
-    let update = updater.check().await.map_err(|e| e.to_string())?;
-
-    Ok(update.is_some())
+/// アップデートをダウンロードしてインストール
+#[tauri::command]
+async fn install_update(app: AppHandle) -> Result<(), String> {
+    update_handler::install(&app).await
 }
 
 /// トークンを保存

--- a/src-tauri/src/update_handler.rs
+++ b/src-tauri/src/update_handler.rs
@@ -1,0 +1,74 @@
+use serde::Serialize;
+use tauri::AppHandle;
+use tauri_plugin_updater::UpdaterExt;
+use url::Url;
+
+use crate::settings_store;
+
+const RELEASE_ENDPOINT: &str =
+    "https://github.com/Takadayoo/vrchat-group-manager/releases/latest/download/latest.json";
+const PRERELEASE_ENDPOINT: &str =
+    "https://github.com/Takadayoo/vrchat-group-manager/releases/download/pre-release/latest.json";
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateInfo {
+    pub version: String,
+    pub body: Option<String>,
+}
+
+fn get_endpoint(include_prerelease: bool) -> &'static str {
+    if include_prerelease {
+        PRERELEASE_ENDPOINT
+    } else {
+        RELEASE_ENDPOINT
+    }
+}
+
+/// アップデートを確認する
+pub async fn check(app: &AppHandle) -> Result<Option<UpdateInfo>, String> {
+    let settings = settings_store::load_settings(app)?;
+    let url = Url::parse(get_endpoint(settings.update.include_prerelease))
+        .map_err(|e| e.to_string())?;
+
+    let update = app
+        .updater_builder()
+        .endpoints(vec![url])
+        .map_err(|e| e.to_string())?
+        .build()
+        .map_err(|e| e.to_string())?
+        .check()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(update.map(|u| UpdateInfo {
+        version: u.version,
+        body: u.body,
+    }))
+}
+
+/// アップデートをダウンロードしてインストールする
+pub async fn install(app: &AppHandle) -> Result<(), String> {
+    let settings = settings_store::load_settings(app)?;
+    let url = Url::parse(get_endpoint(settings.update.include_prerelease))
+        .map_err(|e| e.to_string())?;
+
+    let update = app
+        .updater_builder()
+        .endpoints(vec![url])
+        .map_err(|e| e.to_string())?
+        .build()
+        .map_err(|e| e.to_string())?
+        .check()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    if let Some(update) = update {
+        update
+            .download_and_install(|_chunk: usize, _total: Option<u64>| {}, || {})
+            .await
+            .map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
+}

--- a/src/app/pages/SettingsPage.tsx
+++ b/src/app/pages/SettingsPage.tsx
@@ -28,6 +28,7 @@ import { Separator } from "@/app/components/ui/separator";
 import { Switch } from "@/app/components/ui/switch";
 import { vrcApi } from "@/lib/vrcApi";
 import type { UserInfo } from "@/types";
+import { relaunch } from "@tauri-apps/plugin-process";
 import { Activity, Bell, Code, FileText, Info, LogOut, Palette, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -58,6 +59,7 @@ export const SettingsPage = ({
     includePrerelease: false,
   });
   const [dialogType, setDialogType] = useState<"disableCheck" | "enablePrerelease" | null>(null);
+  const [needsRestart, setNeedsRestart] = useState(false);
 
   // stateではなく定数で十分
   const dummySettings = {
@@ -102,6 +104,9 @@ export const SettingsPage = ({
     const current = await vrcApi.getSettings();
     try {
       await vrcApi.saveSettings({ ...current, update: next });
+      if (next.includePrerelease !== updateSettings.includePrerelease) {
+        setNeedsRestart(true);
+      }
       setUpdateSettings(next);
     } catch (error) {
       console.error(error);
@@ -344,6 +349,21 @@ export const SettingsPage = ({
                 onCheckedChange={handleIncludePrereleaseChange}
               />
             </div>
+
+            {needsRestart && (
+              <>
+                <Separator />
+                <div className="flex items-center justify-between p-3 bg-yellow-50 dark:bg-yellow-950 rounded-md border border-yellow-200 dark:border-yellow-800">
+                  <p className="text-sm text-yellow-800 dark:text-yellow-200">
+                    設定変更を適用するには再起動が必要です
+                  </p>
+                  <Button variant="outline" size="sm" onClick={() => relaunch()}>
+                    <RefreshCw className="size-4 mr-2" />
+                    今すぐ再起動
+                  </Button>
+                </div>
+              </>
+            )}
           </CardContent>
         </Card>
 

--- a/src/hooks/useAutoUpdate.ts
+++ b/src/hooks/useAutoUpdate.ts
@@ -1,6 +1,5 @@
 import { vrcApi } from "@/lib/vrcApi";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { check } from "@tauri-apps/plugin-updater";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
@@ -10,7 +9,7 @@ export const useAutoUpdate = (enabled = false) => {
   const checkForUpdate = async (silent = false) => {
     setIsChecking(true);
     try {
-      const update = await check();
+      const update = await vrcApi.checkForUpdates();
 
       if (update) {
         toast.success(`新しいバージョン ${update.version} が利用可能です`, {
@@ -22,7 +21,7 @@ export const useAutoUpdate = (enabled = false) => {
               try {
                 toast.info("アップデートをダウンロード中...");
 
-                await update.downloadAndInstall();
+                await vrcApi.installUpdate();
 
                 toast.success("アップデート完了！アプリを再起動します");
 

--- a/src/lib/vrcApi.ts
+++ b/src/lib/vrcApi.ts
@@ -89,4 +89,18 @@ export const vrcApi = {
   async saveSettings(settings: AppSettings): Promise<void> {
     await invoke("save_settings_cmd", { settings });
   },
+
+  /**
+   * アップデートを確認する
+   */
+  async checkForUpdates(): Promise<{ version: string; body?: string } | null> {
+    return await invoke<{ version: string; body?: string } | null>("check_for_updates");
+  },
+
+  /**
+   * アップデートをダウンロードしてインストール
+   */
+  async installUpdate(): Promise<void> {
+    await invoke("install_update");
+  },
 };


### PR DESCRIPTION
## 概要

リリース自動化とプレリリース配信の仕組みを構築しました。
Issue #6（起動時アップデート確認）の内容も含みます。

## 主な変更内容

### CI/CD（.github/workflows/）
- `release.yml`: タグプッシュ時に Windows ビルド・GitHub リリースを自動化
- プレリリース判定: タグに `-` を含む場合はプレリリースとして公開
- `pre-release` 固定タグを毎回上書きしてエンドポイント URL を固定
- `version-check.yml`: 3ファイルのバージョン一致チェックを自動化

### プレリリース設定（Rust / TypeScript）
- 設定に応じてアップデートエンドポイントを動的切り替え
- `update_handler.rs` にアップデート処理を切り出し
- 設定変更後に再起動バナーを表示

## テスト確認項目

- [x] ビルド・起動に問題なし
- [x] CI（Lint / Cargo check）パス
